### PR TITLE
Add prototype_2 comparisons

### DIFF
--- a/linestring_vs_cellstring/intersects_long_traj_large_mbr.sql
+++ b/linestring_vs_cellstring/intersects_long_traj_large_mbr.sql
@@ -9,13 +9,24 @@ WHERE trajA.trajectory_id <> trajB.trajectory_id
     AND trajA.trajectory_id = 103078
     AND ST_Intersects(trajA.geom, trajB.geom);
 
---- CellString version (~9s) = 1874 trajectories ---
+--- Prototype 1 CellString version (~9s) = 1874 trajectories ---
 EXPLAIN (ANALYZE, COSTS, BUFFERS)
 SELECT DISTINCT
     trajB.trajectory_id
 FROM
     prototype1.trajectory_cs AS trajA,
     prototype1.trajectory_cs AS trajB
+WHERE trajA.trajectory_id <> trajB.trajectory_id
+    AND trajA.trajectory_id = 103078
+    AND CST_Intersects(trajA.cellstring, trajB.cellstring);
+
+--- Prototype 2 CellString version (~2.5s) = 1874 trajectories ---
+EXPLAIN (ANALYZE, COSTS, BUFFERS)
+SELECT DISTINCT
+    trajB.trajectory_id
+FROM
+    prototype2.trajectory_cs AS trajA,
+    prototype2.trajectory_cs AS trajB
 WHERE trajA.trajectory_id <> trajB.trajectory_id
     AND trajA.trajectory_id = 103078
     AND CST_Intersects(trajA.cellstring, trajB.cellstring);

--- a/linestring_vs_cellstring/intersects_long_traj_small_mbr.sql
+++ b/linestring_vs_cellstring/intersects_long_traj_small_mbr.sql
@@ -16,13 +16,24 @@ WHERE trajA.trajectory_id <> trajB.trajectory_id
     AND trajA.trajectory_id = 9133
     AND ST_Intersects(trajA.geom, trajB.geom);
 
---- CellString version (~1m 7s) = 767 trajectories ---
+--- Prototype 1 CellString version (~1m 7s) = 767 trajectories ---
 EXPLAIN (ANALYZE, COSTS, BUFFERS)
 SELECT DISTINCT
     trajB.trajectory_id
 FROM
     prototype1.trajectory_cs AS trajA,
     prototype1.trajectory_cs AS trajB
+WHERE trajA.trajectory_id <> trajB.trajectory_id
+    AND trajA.trajectory_id = 9133
+    AND CST_Intersects(trajA.cellstring, trajB.cellstring);
+
+--- Prototype 2 CellString version (~7s) = 767 trajectories ---
+EXPLAIN (ANALYZE, COSTS, BUFFERS)
+SELECT DISTINCT
+    trajB.trajectory_id
+FROM
+    prototype2.trajectory_cs AS trajA,
+    prototype2.trajectory_cs AS trajB
 WHERE trajA.trajectory_id <> trajB.trajectory_id
     AND trajA.trajectory_id = 9133
     AND CST_Intersects(trajA.cellstring, trajB.cellstring);

--- a/linestring_vs_cellstring/intersects_traj_with_area.sql
+++ b/linestring_vs_cellstring/intersects_traj_with_area.sql
@@ -66,7 +66,7 @@ SELECT
     traj.trajectory_id,
     traj.mmsi
 FROM
-    prototype1.trajectory_cs AS traj,
+    prototype2.trajectory_cs AS traj,
     benchmark.area_cs as area
 WHERE
     area.area_id = 1

--- a/statistics/db_storage_stats.sql
+++ b/statistics/db_storage_stats.sql
@@ -1,10 +1,14 @@
 SELECT
     --storage size
-    pg_size_pretty(pg_total_relation_size('prototype1.trajectory_cs')) AS cellstring_traj_size,
-    pg_size_pretty(pg_relation_size('prototype1.trajectory_cs')) AS cellstring_traj_size_without_index,
-    pg_size_pretty(pg_indexes_size('prototype1.trajectory_cs')) AS index_size,
-    pg_size_pretty(pg_relation_size('prototype1.trajectory_cellstring_gin_idx')) AS gin_index_size,
-    pg_size_pretty(pg_total_relation_size('prototype1.trajectory_ls')) AS linestring_traj_size,
-    pg_size_pretty(pg_total_relation_size('prototype1.stop_cs')) AS cellstring_stop_size,
-    pg_size_pretty(pg_total_relation_size('prototype1.stop_poly')) AS linestring_stop_size,
-    pg_size_pretty(pg_total_relation_size('prototype1.points')) AS points;
+    pg_size_pretty(pg_total_relation_size('prototype1.trajectory_cs')) AS pt1_cellstring_traj_size,
+    pg_size_pretty(pg_total_relation_size('prototype2.trajectory_cs')) AS pt2_cellstring_traj_size,
+    pg_size_pretty(pg_relation_size('prototype1.trajectory_cs')) AS pt1_cellstring_traj_size_without_index,
+    pg_size_pretty(pg_relation_size('prototype2.trajectory_cs')) AS pt2_cellstring_traj_size_without_index,
+    pg_size_pretty(pg_indexes_size('prototype1.trajectory_cs')) AS pt1_index_size,
+    pg_size_pretty(pg_indexes_size('prototype2.trajectory_cs')) AS pt2_index_size,
+    pg_size_pretty(pg_relation_size('prototype1.trajectory_cellstring_gin_idx')) AS pt1_gin_index_size,
+    pg_size_pretty(pg_relation_size('prototype2.trajectory_cellstring_gin_idx')) AS pt2_gin_index_size,
+    pg_size_pretty(pg_total_relation_size('prototype1.trajectory_ls')) AS pt1_linestring_traj_size,
+    pg_size_pretty(pg_total_relation_size('prototype1.stop_cs')) AS pt1_cellstring_stop_size,
+    pg_size_pretty(pg_total_relation_size('prototype1.stop_poly')) AS pt1_linestring_stop_size,
+    pg_size_pretty(pg_total_relation_size('prototype1.points')) AS pt1_points;

--- a/statistics/proto1_vs_proto2.sql
+++ b/statistics/proto1_vs_proto2.sql
@@ -1,0 +1,27 @@
+-- Sum the number of cells as CARDINALITY(cellstring) per trajectory
+WITH p1 AS (
+  SELECT
+    trajectory_id,
+    SUM(COALESCE(CARDINALITY(cellstring), 0)) AS cell_count
+  FROM prototype1.trajectory_cs
+  GROUP BY trajectory_id
+),
+p2 AS (
+  SELECT
+    trajectory_id,
+    SUM(COALESCE(CARDINALITY(cellstring), 0)) AS cell_count
+  FROM prototype2.trajectory_cs
+  GROUP BY trajectory_id
+)
+SELECT
+  COALESCE(p1.trajectory_id, p2.trajectory_id) AS trajectory_id,
+  COALESCE(p1.cell_count, 0) AS p1_cell_count,
+  COALESCE(p2.cell_count, 0) AS p2_cell_count,
+  COALESCE(p2.cell_count, 0) - COALESCE(p1.cell_count, 0) AS diff,
+  CASE
+    WHEN COALESCE(p1.cell_count, 0) = 0 THEN NULL
+    ELSE ROUND(100.0 * (COALESCE(p2.cell_count, 0) - COALESCE(p1.cell_count, 0)) / p1.cell_count, 2)
+  END AS pct_change_from_p1
+FROM p1
+FULL OUTER JOIN p2 USING (trajectory_id)
+ORDER BY diff;

--- a/utils/find_worst_num_cells_to_num_points.sql
+++ b/utils/find_worst_num_cells_to_num_points.sql
@@ -16,3 +16,22 @@ JOIN prototype1.trajectory_cs AS traj_cs
     ON traj_ls.trajectory_id = traj_cs.trajectory_id
 WHERE ST_NumPoints(traj_ls.geom) > 1000
 ORDER BY points_cells_ratio DESC;
+
+SELECT
+    traj_ls.trajectory_id,
+    ST_NumPoints(traj_ls.geom) AS num_points,
+    ST_Length(ST_Transform(traj_ls.geom, 3857)) AS traj_length,
+    cardinality(traj_cs.cellstring) AS num_cells,
+    CASE
+        WHEN cardinality(traj_cs.cellstring) > 0
+        THEN ROUND(
+            cardinality(traj_cs.cellstring)::NUMERIC / ST_NumPoints(traj_ls.geom),
+            2
+        )
+        ELSE NULL
+    END AS points_cells_ratio
+FROM prototype1.trajectory_ls AS traj_ls
+JOIN prototype2.trajectory_cs AS traj_cs
+    ON traj_ls.trajectory_id = traj_cs.trajectory_id
+--WHERE ST_NumPoints(traj_ls.geom) > 1000
+ORDER BY points_cells_ratio DESC;

--- a/visualisations/visualise_cellstring_of_traj_or_stop_as_multipolygon.sql
+++ b/visualisations/visualise_cellstring_of_traj_or_stop_as_multipolygon.sql
@@ -8,9 +8,9 @@ SELECT
     ls.geom AS trajectory_geom,
     ls_experiment.cellids_to_polygons(cs.cellstring) AS trajectory_cells
 FROM prototype1.trajectory_ls ls
-JOIN prototype1.trajectory_cs cs
+JOIN prototype2.trajectory_cs cs
   ON ls.trajectory_id = cs.trajectory_id
-WHERE ls.trajectory_id IN (12);
+WHERE ls.trajectory_id IN (20521);
 
 
 -- Stop


### PR DESCRIPTION
This pull request introduces updates to SQL scripts and statistics queries to compare and analyze two different prototypes (`prototype1` and `prototype2`) for storing and processing trajectory data. The changes focus on enabling side-by-side performance and storage comparisons, adding new queries for prototype 2, and updating existing queries to use prototype 2 tables where appropriate.

**Prototype comparison and query updates:**

* Added new queries for "Prototype 2 CellString" intersections in both `intersects_long_traj_large_mbr.sql` and `intersects_long_traj_small_mbr.sql` to benchmark performance and results against Prototype 1. [[1]](diffhunk://#diff-a868070d4135cf9b68ed90c741ddf5101deb3d88e90fca15500bad5d6a83c820R22-R32) [[2]](diffhunk://#diff-6b3853b357b6ef539eeeeab8471a6f91accdd301dea88b0c7748797dd77e1b7aR29-R39)
* Updated the trajectory-area intersection query in `intersects_traj_with_area.sql` to use `prototype2.trajectory_cs` instead of `prototype1.trajectory_cs`.
* Modified the cellstring visualisation script to join with `prototype2.trajectory_cs` and updated the example trajectory ID.

**Statistics and analysis enhancements:**

* Refactored `db_storage_stats.sql` to report storage size statistics for both prototypes, including table size, index size, and GIN index size for each.
* Added a new script `proto1_vs_proto2.sql` to compare the number of cells per trajectory between Prototype 1 and Prototype 2, including percent change calculations.
* Extended the "worst-case" cell-to-point ratio analysis to include Prototype 2, allowing direct comparison with Prototype 1 in `find_worst_num_cells_to_num_points.sql`.

**Documentation and commentary improvements:**

* Clarified query section headers to specify "Prototype 1" and "Prototype 2" for better readability and benchmarking. [[1]](diffhunk://#diff-a868070d4135cf9b68ed90c741ddf5101deb3d88e90fca15500bad5d6a83c820L12-R12) [[2]](diffhunk://#diff-6b3853b357b6ef539eeeeab8471a6f91accdd301dea88b0c7748797dd77e1b7aL19-R19)