### PR TITLE
Add benchmark for stop intersection spatially and temporally

### DIFF
--- a/benchmarking/benchmarks/__init__.py
+++ b/benchmarking/benchmarks/__init__.py
@@ -1,9 +1,11 @@
 from .intersects_area_benchmark import BENCHMARK as intersects_area_benchmark
 from .intersects_traj_benchmark import BENCHMARK as intersects_traj_benchmark
 from .hausdorff_distance_benchmark import BENCHMARK as hausdorff_distance_benchmark
+from .intersects_with_stop_spatially_and_temporally import BENCHMARK as intersects_with_stop_spatially_and_temporally_benchmark
 
 RUN_PLAN = [
     intersects_traj_benchmark,
     intersects_area_benchmark,
     hausdorff_distance_benchmark,
+    intersects_with_stop_spatially_and_temporally_benchmark,
 ]

--- a/benchmarking/benchmarks/intersects_with_stop_spatially_and_temporally.py
+++ b/benchmarking/benchmarks/intersects_with_stop_spatially_and_temporally.py
@@ -1,0 +1,136 @@
+from benchmarking.core import TimeBenchmark
+
+ST_SQL = """
+WITH ref AS (
+    SELECT mmsi,
+           stop_id,
+           geom AS ref_geom,
+           ts_start AS ref_start,
+           ts_end   AS ref_end
+    FROM prototype2.stop_poly
+    WHERE stop_id = %s
+)
+
+-- 0. Reference stop (always returned)
+SELECT
+    'REFERENCE STOP' as type,
+    r.mmsi,
+    NULL::bigint AS trajectory_id,
+    r.stop_id,
+    NULL::double precision AS overlap_minutes
+FROM ref r
+
+UNION
+
+-- 1. Trajectory matches
+SELECT DISTINCT
+    'INTERSECTING TRAJECTORY' as type,
+    t.mmsi,
+    t.trajectory_id,
+    NULL::bigint AS stop_id,
+    ROUND(EXTRACT(
+        EPOCH FROM (
+            LEAST(t.ts_end,   r.ref_end)
+          - GREATEST(t.ts_start, r.ref_start)
+        )
+    ) / 60.0, 2) AS overlap_minutes
+FROM ref r
+JOIN prototype2.trajectory_ls t
+  ON t.mmsi <> r.mmsi
+ AND ST_Intersects(t.geom, r.ref_geom)
+ AND t.ts_end   >= r.ref_start
+ AND t.ts_start <= r.ref_end
+
+UNION
+
+-- 2. Stop matches
+SELECT DISTINCT
+    'INTERSECTING STOP' as type,
+    s.mmsi,
+    NULL::bigint AS trajectory_id,
+    s.stop_id,
+    ROUND(EXTRACT(
+        EPOCH FROM (
+            LEAST(s.ts_end,   r.ref_end)
+          - GREATEST(s.ts_start, r.ref_start)
+        )
+    ) / 60.0, 2) AS overlap_minutes
+FROM ref r
+JOIN prototype2.stop_poly s
+  ON s.mmsi <> r.mmsi
+ AND ST_Intersects(s.geom, r.ref_geom)
+ AND s.ts_end   >= r.ref_start
+ AND s.ts_start <= r.ref_end;
+"""
+
+CST_SQL = """
+WITH ref AS (
+    SELECT mmsi,
+           stop_id,
+           cellstring_{zoom} as ref_cellstring,
+           ts_start AS ref_start,
+           ts_end   AS ref_end
+    FROM prototype2.stop_cs
+    WHERE stop_id = %s
+)
+
+-- 0. Reference stop (always returned)
+SELECT
+    'REFERENCE STOP' as type,
+    r.mmsi,
+    NULL::bigint AS trajectory_id,
+    r.stop_id,
+    NULL::double precision AS overlap_minutes
+FROM ref r
+
+UNION
+
+-- 1. Trajectory matches
+SELECT DISTINCT
+    'INTERSECTING TRAJECTORY' as type,
+    t.mmsi,
+    t.trajectory_id,
+    NULL::bigint AS stop_id,
+    ROUND(EXTRACT(
+        EPOCH FROM (
+            LEAST(t.ts_end,   r.ref_end)
+          - GREATEST(t.ts_start, r.ref_start)
+        )
+    ) / 60.0, 2) AS overlap_minutes
+FROM ref r
+JOIN prototype2.trajectory_supercover_cs t
+  ON t.mmsi <> r.mmsi
+ AND CST_Intersects(t.cellstring_{zoom}, r.ref_cellstring)
+ AND t.ts_end   >= r.ref_start
+ AND t.ts_start <= r.ref_end
+
+UNION
+
+-- 2. Stop matches
+SELECT DISTINCT
+    'INTERSECTING STOP' as type,
+    s.mmsi,
+    NULL::bigint AS trajectory_id,
+    s.stop_id,
+    ROUND(EXTRACT(
+        EPOCH FROM (
+            LEAST(s.ts_end,   r.ref_end)
+          - GREATEST(s.ts_start, r.ref_start)
+        )
+    ) / 60.0, 2) AS overlap_minutes
+FROM ref r
+JOIN prototype2.stop_cs s
+  ON s.mmsi <> r.mmsi
+ AND CST_Intersects(s.cellstring_{zoom}, r.ref_cellstring)
+ AND s.ts_end   >= r.ref_start
+ AND s.ts_start <= r.ref_end;
+"""
+
+BENCHMARK = TimeBenchmark(
+    name="Find trajectories and stops that intersect a given stop spatially and temporally",
+    st_sql=ST_SQL,
+    cst_sql=CST_SQL,
+    with_stop_ids=True,
+    zoom_levels=["z13", "z17", "z21"],
+)
+

--- a/benchmarking/core.py
+++ b/benchmarking/core.py
@@ -15,6 +15,7 @@ class TimeBenchmark:
     params: Tuple[Any, ...] = tuple()
     repeats: int = 5
     with_trajectory_ids: bool = False
+    with_stop_ids: bool = False
     zoom_levels: List[str] = field(default_factory=list)
     area_ids: List[int] = field(default_factory=list)
     use_area_ids: bool = False
@@ -111,6 +112,7 @@ def _execute_random_or_repeated_queries(
         repeats: int | None = None,
         timeout_seconds: int | None,
         trajectory_ids: List[int] | None = None,
+        stop_ids: List[int] | None = None,
 ) -> RunOutcome:
     if trajectory_ids is not None and not trajectory_ids:
         return RunOutcome(0.0, 0.0, [])
@@ -126,6 +128,17 @@ def _execute_random_or_repeated_queries(
 
             for trajectory_id in trajectory_ids:
                 current_params = (trajectory_id,) + params
+                rows, wall_ms = _fetch_all_with_wall_ms(cur, sql, current_params, timeout_seconds)
+                _, exec_ms = _explain_analyze_ms(cur, sql, current_params)
+                exec_times.append(exec_ms)
+                wall_times.append(wall_ms)
+                collected_rows.extend(rows)
+        elif stop_ids is not None:
+            first_params = (stop_ids[0],) + params
+            _warmup(cur, sql, first_params, timeout_seconds)
+
+            for stop_id in stop_ids:
+                current_params = (stop_id,) + params
                 rows, wall_ms = _fetch_all_with_wall_ms(cur, sql, current_params, timeout_seconds)
                 _, exec_ms = _explain_analyze_ms(cur, sql, current_params)
                 exec_times.append(exec_ms)
@@ -156,7 +169,7 @@ def _execute_random_or_repeated_queries(
         raise
 
 
-def run_time_benchmark(connection, bench: TimeBenchmark, trajectory_ids: List[int]) -> TimeBenchmarkResult:
+def run_time_benchmark(connection, bench: TimeBenchmark, trajectory_ids: List[int] | None = None, stop_ids: List[int] | None = None) -> TimeBenchmarkResult:
     connection.autocommit = True
     connection.prepare_threshold = None
     per_area_results: Dict[int, Dict[str, RunOutcome]] = {}
@@ -209,6 +222,24 @@ def run_time_benchmark(connection, bench: TimeBenchmark, trajectory_ids: List[in
                     bench.params,
                     timeout_seconds=bench.timeout_seconds,
                     trajectory_ids=trajectory_ids
+                )
+        elif bench.with_stop_ids:
+            st_out = _execute_random_or_repeated_queries(
+                cur,
+                bench.st_sql,
+                bench.params,
+                timeout_seconds=bench.timeout_seconds,
+                stop_ids=stop_ids
+            )
+            cst_results = {}
+            for zoom in bench.zoom_levels:
+                sql = bench.cst_sql.format(zoom=zoom)
+                cst_results[zoom] = _execute_random_or_repeated_queries(
+                    cur,
+                    sql,
+                    bench.params,
+                    timeout_seconds=bench.timeout_seconds,
+                    stop_ids=stop_ids
                 )
         else:
             st_out = _execute_random_or_repeated_queries(

--- a/benchmarking/main.py
+++ b/benchmarking/main.py
@@ -52,16 +52,33 @@ def _build_length_stats(stat_entries):
         )
     return stats
 
+
 def _print_trajectory_stats(stat_entries, sample_size):
-    stats = _build_length_stats(stat_entries)
-    if not stats:
+    if not stat_entries:
+        print("\nNo trajectory statistics available.")
         return []
+    stats = _build_length_stats(stat_entries)
     print(f"\n{sample_size} trajectory statistics:")
     for entry in stats:
         print(
             f"{entry['label']}: Min length: {entry['min']}, "
             f"Median length: {entry['median']}, "
             f"Max length: {entry['max']}"
+        )
+    return stats
+
+
+def _print_stop_stats(stat_entries, sample_size):
+    if not stat_entries:
+        print("\nNo stop statistics available.")
+        return []
+    stats = _build_length_stats(stat_entries)
+    print(f"\n{sample_size} stop statistics:")
+    for entry in stats:
+        print(
+            f"{entry['label']}: Min size: {entry['min']}, "
+            f"Median size: {entry['median']}, "
+            f"Max size: {entry['max']}"
         )
     return stats
 
@@ -83,12 +100,27 @@ def _collect_tables_from_benchmark(benchmark):
     return []
 
 
+def _fetch_random_ids(cur, column_name, table_name, sample_size):
+    if sample_size <= 0:
+        return []
+    if not re.fullmatch(r"[A-Za-z0-9_]+", column_name):
+        raise ValueError(f"Invalid column name: {column_name}")
+    if not re.fullmatch(r"[A-Za-z0-9_.]+", table_name):
+        raise ValueError(f"Invalid table name: {table_name}")
+    cur.execute(
+        f"SELECT {column_name} FROM {table_name} ORDER BY random() LIMIT %s",
+        (sample_size,)
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
 def _serialize_run_outcome(run: RunOutcome) -> dict:
     return {
         "exec_ms_med": run.exec_ms_med,
         "wall_ms_med": run.wall_ms_med,
         "timed_out": run.timed_out,
     }
+
 
 def _serialize_time_result(result: TimeBenchmarkResult) -> dict:
     return {
@@ -120,6 +152,11 @@ def _write_json_report(payload: dict, run_started_at: datetime) -> Path:
 
 def main():
     load_dotenv()
+    trajectory_source_table = "prototype2.trajectory_cs"
+    stop_source_table = "prototype2.stop_cs"
+    trajectory_sample_size = 5
+    stop_sample_size = 30
+
     db_url = os.getenv("DATABASE_URL")
     if not db_url:
         sys.exit("DATABASE_URL not defined in .env file")
@@ -129,28 +166,59 @@ def main():
     conn = connect_to_db()
     try:
         trajectory_ids = []
-        linestring_lengths = []
-        cellstring_lengths = {zoom: [] for zoom in ZOOM_LEVELS}
+        stop_ids = []
+
+        traj_linestring_lengths = []
+        stop_linestring_lengths = []
+        traj_cellstring_lengths = {zoom: [] for zoom in ZOOM_LEVELS}
+        stop_cellstring_lengths = {zoom: [] for zoom in ZOOM_LEVELS}
+
         benchmark_outputs = []
 
         with conn.cursor() as cur:
-            cur.execute("SELECT trajectory_id FROM prototype2.trajectory_ls ORDER BY random() LIMIT 5")
-            trajectory_ids = [row[0] for row in cur.fetchall()]
+            trajectory_ids = _fetch_random_ids(
+                cur,
+                "trajectory_id",
+                trajectory_source_table,
+                trajectory_sample_size,
+            )
+            stop_ids = _fetch_random_ids(
+                cur,
+                "stop_id",
+                stop_source_table,
+                stop_sample_size,
+            )
 
             if trajectory_ids:
                 cur.execute(
-                    "SELECT ST_Length(ST_Transform(geom, 3857)) FROM prototype2.trajectory_ls WHERE trajectory_id = ANY(%s)",
+                    "SELECT ST_Length(ST_Transform(geom, 3857)) "
+                    "FROM prototype2.trajectory_ls WHERE trajectory_id = ANY(%s)",
                     (trajectory_ids,)
                 )
-                linestring_lengths = [row[0] for row in cur.fetchall() if row[0] is not None]
+                traj_linestring_lengths = [row[0] for row in cur.fetchall() if row[0] is not None]
 
                 for zoom in ZOOM_LEVELS:
                     cur.execute(
                         f"SELECT Cardinality(cellstring_{zoom}) "
-                        "FROM prototype2.trajectory_cs WHERE trajectory_id = ANY(%s)",
+                        f"FROM {trajectory_source_table} WHERE trajectory_id = ANY(%s)",
                         (trajectory_ids,)
                     )
-                    cellstring_lengths[zoom] = [row[0] for row in cur.fetchall() if row[0] is not None]
+                    traj_cellstring_lengths[zoom] = [row[0] for row in cur.fetchall() if row[0] is not None]
+            if stop_ids:
+                cur.execute(
+                    "SELECT ST_Area(ST_Transform(geom, 3857)) "
+                    "FROM prototype2.stop_poly WHERE stop_id = ANY(%s)",
+                    (stop_ids,)
+                )
+                stop_linestring_lengths = [row[0] for row in cur.fetchall() if row[0] is not None]
+
+                for zoom in ZOOM_LEVELS:
+                    cur.execute(
+                        f"SELECT Cardinality(cellstring_{zoom}) "
+                        f"FROM {stop_source_table} WHERE stop_id = ANY(%s)",
+                        (stop_ids,)
+                    )
+                    stop_cellstring_lengths[zoom] = [row[0] for row in cur.fetchall() if row[0] is not None]
 
         for benchmark in RUN_PLAN:
             bench_instance = benchmark
@@ -162,7 +230,10 @@ def main():
             tables_used = _collect_tables_from_benchmark(bench_instance)
 
             if isinstance(bench_instance, TimeBenchmark):
-                result = run_time_benchmark(conn, bench_instance, trajectory_ids)
+                if bench_instance.with_trajectory_ids:
+                    result = run_time_benchmark(conn, bench_instance, trajectory_ids=trajectory_ids)
+                elif bench_instance.with_stop_ids:
+                    result = run_time_benchmark(conn, bench_instance, stop_ids=stop_ids)
                 print_time_result(result)
                 benchmark_outputs.append(
                     {
@@ -184,24 +255,40 @@ def main():
                     }
                 )
 
-        stats_payload = []
-        if linestring_lengths:
-            stats_payload.append(("LineString", linestring_lengths))
+        traj_stats_payload = []
+        stop_stats_payload = []
+        if traj_linestring_lengths:
+            traj_stats_payload.append(("LineString", traj_linestring_lengths))
         for zoom in ZOOM_LEVELS:
-            lengths = cellstring_lengths.get(zoom)
+            lengths = traj_cellstring_lengths.get(zoom)
             if lengths:
-                stats_payload.append((f"CellString_{zoom}", lengths))
-        stats_summary = _print_trajectory_stats(stats_payload, len(trajectory_ids))
+                traj_stats_payload.append((f"CellString_{zoom}", lengths))
+        traj_stats_summary = _print_trajectory_stats(traj_stats_payload, len(trajectory_ids))
+        if stop_linestring_lengths:
+            stop_stats_payload.append(("LineString", stop_linestring_lengths))
+        for zoom in ZOOM_LEVELS:
+            lengths = stop_cellstring_lengths.get(zoom)
+            if lengths:
+                stop_stats_payload.append((f"CellString_{zoom}", lengths))
+        stop_stats_summary = _print_stop_stats(stop_stats_payload, len(stop_ids))
         all_tables_used = sorted({table for entry in benchmark_outputs for table in entry["tables_used"]})
+        tested_types = []
+        if traj_stats_summary:
+            tested_types.extend(entry["label"] for entry in traj_stats_summary)
+        if stop_stats_summary:
+            tested_types.extend(entry["label"] for entry in stop_stats_summary)
 
         report = {
             "meta": {
                 "run_started_at": run_started_at.isoformat(),
                 "trajectory_count": len(trajectory_ids),
                 "trajectory_ids": trajectory_ids,
+                "stop_count": len(stop_ids),
+                "stop_ids": stop_ids,
                 "zoom_levels": ZOOM_LEVELS,
-                "trajectory_stats": stats_summary,
-                "tested_types": [entry["label"] for entry in stats_summary],
+                "trajectory_stats": traj_stats_summary,
+                "stop_stats": stop_stats_summary,
+                "tested_types": tested_types,
                 "tables_used": all_tables_used,
             },
             "benchmarks": benchmark_outputs,


### PR DESCRIPTION
Introduces a new benchmark to find trajectories and stops that intersect a given stop both spatially and temporally. Updates core logic to support benchmarking with stop IDs, adds related SQL queries, and extends main script to sample and report stop statistics alongside trajectory statistics.